### PR TITLE
Enable version updates for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/restapigw"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+      
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/restapigw/web"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+
+  # Enable version updates for Docker
+# - package-ecosystem: "docker"
+    # Look for a `Dockerfile` in the `root` directory
+#   directory: "/"
+    # Check for updates once a week
+#   schedule:
+#     interval: "weekly"


### PR DESCRIPTION
CC: @hermitkim1

From:
- https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/
- https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-and-disabling-version-updates

[사유]
https://github.com/cloud-barista/cb-apigw/security/dependabot/restapigw/web/yarn.lock/axios/open
이것을 보면,
Dependabot 이 `axios` 를 `0.20.0` 에서 `0.21.1` 로 업데이트하고 싶어하는데,
다른 package 의 dependency 때문에 업데이트 하지 못하는 것을 볼 수 있습니다.

npm 패키지들에 대해 자동업데이트를 적용하면
위의 문제를 해소할 수 있지 않을까 합니다.