### PR TITLE
Disable multi-arch container image build

### DIFF
--- a/.github/workflows/build-and-publish-container-image.yaml
+++ b/.github/workflows/build-and-publish-container-image.yaml
@@ -98,7 +98,7 @@ jobs:
           context: ./restapigw/
           file: ./restapigw/Dockerfile
           target: prod
-          platforms: linux/amd64,linux/arm/v7,linux/arm64 # linux/386,linux/ppc64le,linux/s390x,linux/arm/v6
+          platforms: linux/amd64 # linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x,linux/arm/v6
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ steps.prep.outputs.docker-tags }}


### PR DESCRIPTION
Let's see whether CI build successes or fails.