### PR TITLE
Update HMAC server's Dockerfile

### DIFF
--- a/restapigw/deploy/web/Dockerfile
+++ b/restapigw/deploy/web/Dockerfile
@@ -9,14 +9,15 @@ RUN apk update && apk add --no-cache git
 
 WORKDIR /app
 
-ADD go.mod .
-ADD main.go .
+ADD go.mod go.sum main.go ./
 
 # download dependencies
-RUN go get github.com/labstack/echo/v4 && \
-  go get github.com/spf13/viper && \
+#RUN go get github.com/labstack/echo/v4 && \
+#  go get github.com/spf13/viper && \
   # build the binary
-  CGO_ENABLED=0 go build -o ./hmac_server -v ./... && \
+#  CGO_ENABLED=0 go build -o ./hmac_server -v ./... && \
+#  chmod +x ./hmac_server
+RUN CGO_ENABLED=0 go build -o ./hmac_server -v ./... && \
   chmod +x ./hmac_server
 
 ##############################################################
@@ -33,3 +34,4 @@ COPY --from=builder /app/hmac_server .
 ENTRYPOINT [ "/app/hmac_server" ]
 
 EXPOSE 8010
+

--- a/restapigw/deploy/web/go.mod
+++ b/restapigw/deploy/web/go.mod
@@ -1,4 +1,4 @@
-module github.com/ccambo/gosamples/hmac
+module github.com/cloud-barista/cb-apigw/restapigw/deploy/web
 
 go 1.13
 

--- a/restapigw/deploy/web/public/index.html
+++ b/restapigw/deploy/web/public/index.html
@@ -18,14 +18,14 @@
     <!-- Vue.js -->
     <script src="//cdnjs.cloudflare.com/ajax/libs/vue/1.0.24/vue.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/vue-resource/0.7.0/vue-resource.min.js"></script>
-    <title>ETRI || CB-RESTAPIGW :: HMAC Token</title>
+    <title>cb-restapigw :: HMAC Token</title>
 </head>
 
 <body>
     <div class="container" id="app">
         <div class="row">
             <div class="col-md-8">
-                <h2>CB-RESTAPIGW :: HMAC Token</h2>
+                <h2>cb-restapigw :: HMAC Token</h2>
                 <div class="input-group">
                     <input type="text" id="access_key" class="form-control" placeholder="Access Key" v-on:keyup.enter="moveFocus" v-model="task.AccessKey">
                     <input type="text" id="duration" class="form-control" placeholder="Duration for Access" v-on:keyup.enter="moveFocus" v-model="task.Duration">
@@ -122,3 +122,4 @@
 </body>
 
 </html>
+


### PR DESCRIPTION
- HMAC server: cb-restapigw 의 인증 처리 기능 테스트를 위한 구성요소 입니다.
`cb-apigw/restapigw/deploy/web/` 에 소스코드가 있습니다.
- HMAC server's Dockerfile: HMAC server 컨테이너 이미지 빌드에 대한 명세입니다.
- `cb-apigw/restapigw/deploy/web/go.mod` 에
`github.com/labstack/echo/v4` 와
`github.com/spf13/viper` 가 있음에도
`Dockerfile` 에서 이 둘에 대해 `go get` 을 하고 있었습니다.
- `go.mod` 파일을 이용하여 Go 의존성을 다운로드 하도록, 
`Dockerfile` 에서 `go get` 라인을 삭제했습니다.